### PR TITLE
Support parsing `github.com/rs/zerolog/log.Panic.(*Logger).Panic.func1({0x2705549?, 0x0?})`

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -425,7 +425,6 @@ main.runGrpcServer({0x2ab9298?, 0x41fb5c0}, {0x0?}, 0xc0003dc680, 0xc0005b8690, 
 created by main.mainInner in goroutine 1
 	/app/cmd/server/main.go:520 +0x44c`,
 		Result: &sentry.Event{
-			Message: "", //"Failed to create zitadel client",
 			Exception: []sentry.Exception{
 				{
 					Type:     "Failed to create zitadel client",


### PR DESCRIPTION
Previously we didn't like the first `.Panic.` in there.

With test case.

I worked on the regex on https://regex101.com/ -- I added named groups to make it easier to work with.